### PR TITLE
Corrected typo in README.md module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _As of February 2019 I no longer intend to update or extend this module. VS Code
 Install the module from the PowerShell Gallery.
 
 ```powershell
-Install-Module ISScriptingGeek
+Install-Module ISEScriptingGeek
 ```
 
 Then in your PowerShell_ISE profile script, import the module.


### PR DESCRIPTION
Module name for install cmdlet was `ISScriptingGeek`; resulting in ObjectNotFound. Updated it to `ISEScriptingGeek` & verified with PowerShellGet 2.2.5

Minor issue but I didn't notice the typo when I tried it at first and was about to install manually, so hope this is helpful (this is my first PR so criticism is welcome)